### PR TITLE
Static variables are thread local #rust #cpp #java

### DIFF
--- a/cpp/inter/node.cpp
+++ b/cpp/inter/node.cpp
@@ -1,5 +1,5 @@
 #include "cpp/inter/node.hpp"
 
 namespace inter {
-std::atomic_uint32_t Node::labels_{};
+thread_local std::uint32_t Node::labels_ = 0;
 }  // namespace inter

--- a/cpp/inter/node.hpp
+++ b/cpp/inter/node.hpp
@@ -1,6 +1,5 @@
 #pragma once
 
-#include <atomic>
 #include <cstddef>
 #include <cstdint>
 #include <exception>
@@ -28,7 +27,7 @@ class Node {
   std::size_t lexline_;
 
  private:
-  static std::atomic_uint32_t labels_;
+  static thread_local std::uint32_t labels_;
 };
 
 inline Node::Node() : lexline_(lexer::Lexer::current_line()) {

--- a/cpp/inter/temporary.cpp
+++ b/cpp/inter/temporary.cpp
@@ -1,5 +1,5 @@
 #include "cpp/inter/temporary.hpp"
 
 namespace inter {
-std::atomic_uint32_t Temporary::count_{};
+thread_local std::uint32_t Temporary::count_ = 0;
 }  // namespace inter

--- a/cpp/inter/temporary.hpp
+++ b/cpp/inter/temporary.hpp
@@ -1,6 +1,5 @@
 #pragma once
 
-#include <atomic>
 #include <cstdint>
 #include <memory>
 #include <sstream>
@@ -25,7 +24,7 @@ class Temporary : public Expression {
   static void reset_temp_count();
 
  private:
-  static std::atomic_uint32_t count_;
+  static thread_local std::uint32_t count_;
   std::uint32_t number_;
 };
 

--- a/java/com/dragon/inter/Node.java
+++ b/java/com/dragon/inter/Node.java
@@ -1,7 +1,5 @@
 package com.dragon.inter;
 
-import java.util.concurrent.atomic.AtomicInteger;
-
 public class Node {
   Node() {}
 
@@ -13,12 +11,14 @@ public class Node {
     throw new Error(s);
   }
 
-  private static final AtomicInteger labels = new AtomicInteger(0);
+  private static final ThreadLocal<Integer> labels = ThreadLocal.withInitial(() -> 1);
   public static int newLabel() {
-    return labels.addAndGet(1);
+    var lbl = labels.get();
+    labels.set(lbl+1);
+    return lbl;
   }
   public static void resetLabel() {
-    labels.getAndSet(0);
+    labels.set(1);
   }
 
   public static void emitLabel(StringBuilder b, int i) {

--- a/java/com/dragon/inter/Temp.java
+++ b/java/com/dragon/inter/Temp.java
@@ -1,20 +1,17 @@
 package com.dragon.inter;
 
-import java.util.concurrent.atomic.AtomicInteger;
-
 import com.dragon.lexer.Word;
 import com.dragon.symbols.Type;
 
 public class Temp extends Expr {
-  private static final AtomicInteger count = new AtomicInteger(0);
+  private static final ThreadLocal<Integer> count = ThreadLocal.withInitial(() -> 1);
 
   private int number = 0;
 
   public Temp(Type t) {
     super(Word.temp, t);
-    number = count.addAndGet(1);
-    var next = number+1;
-    count.compareAndSet(number, next);
+    number = count.get();
+    count.set(number+1);
   }
 
   @Override
@@ -23,6 +20,6 @@ public class Temp extends Expr {
   }
 
   static public void resetTempCount() {
-    count.getAndSet(0);
+    count.set(1);
   }
 }


### PR DESCRIPTION
This allows for tests to be run in a multi thread way.

Relying on static variables is a problem from the original design. A better approach is to let the parser managing the generation of labels and temp suffixes.