### PR TITLE
Final implementation of the parser #rust

### DIFF
--- a/golang/parser/parser_test.go
+++ b/golang/parser/parser_test.go
@@ -34,6 +34,13 @@ L2:`,
 L2:`,
 	},
 	{
+		`{int i;int[20] arr; i = 10; arr[i] = 10;}`,
+		`L1:	i = 10
+L3:	t1 = i * 4
+	arr [ t1 ] = 10
+L2:`,
+	},
+	{
 		`{int i; int j; bool a; i = i + 10; j = 11; a = i == j;}`,
 		`L1:	i = i + 10
 L3:	j = 11
@@ -63,6 +70,22 @@ L2:`,
 		`{int i; int j; while (true) i = i + 1;}`,
 		`L1:L3:	i = i + 1
 	goto L1
+L2:`,
+	},
+	{
+		`{while (true) {break;} }`,
+		`L1:L3:	goto L2
+	goto L1
+L2:`,
+	},
+	{
+		`{int i; int j; i = 10; j = 1; while (j < i) { i = i + 1; break;} }`,
+		`L1:	i = 10
+L3:	j = 1
+L4:	iffalse j < i goto L2
+L5:	i = i + 1
+L6:	goto L2
+	goto L4
 L2:`,
 	},
 	{

--- a/rust/inter/expression.rs
+++ b/rust/inter/expression.rs
@@ -358,7 +358,7 @@ impl Expression for AccessOp {
   }
 
   fn generate(&self, b: &mut String) -> Result<Box<dyn Expression>, String> {
-    let idx = self.index.generate(b)?;
+    let idx = self.index.reduce(b)?;
     Ok(Box::new(AccessOp::new(self.array.clone(), idx, &self.typ)))
   }
 

--- a/rust/inter/inter.rs
+++ b/rust/inter/inter.rs
@@ -9,12 +9,12 @@ pub mod expression;
 pub mod statement;
 
 thread_local! {
-static label_counter: RefCell<i64> = RefCell::new(1);
+static LABEL_COUNTER: RefCell<i64> = RefCell::new(1);
 }
 
 pub fn new_label() -> i64 {
   let mut res = 0;
-  label_counter.with(|counter| {
+  LABEL_COUNTER.with(|counter| {
     res = *counter.borrow();
     *counter.borrow_mut() = res + 1
   });
@@ -22,7 +22,7 @@ pub fn new_label() -> i64 {
 }
 
 pub fn reset_labels() {
-  label_counter.with(|counter| {
+  LABEL_COUNTER.with(|counter| {
     *counter.borrow_mut() = 1;
   });
 }
@@ -70,23 +70,23 @@ impl Type {
   }
 
   fn integer() -> &'static Type {
-    static t: Lazy<Type> = Lazy::new(|| Type::new(Token::integer()).unwrap());
-    &*t
+    static TYP: Lazy<Type> = Lazy::new(|| Type::new(Token::integer()).unwrap());
+    &*TYP
   }
 
   fn float() -> &'static Type {
-    static t: Lazy<Type> = Lazy::new(|| Type::new(Token::float()).unwrap());
-    &*t
+    static TYP: Lazy<Type> = Lazy::new(|| Type::new(Token::float()).unwrap());
+    &*TYP
   }
 
   fn ch() -> &'static Type {
-    static t: Lazy<Type> = Lazy::new(|| Type::new(Token::ch()).unwrap());
-    &*t
+    static TYP: Lazy<Type> = Lazy::new(|| Type::new(Token::ch()).unwrap());
+    &*TYP
   }
 
   fn boolean() -> &'static Type {
-    static t: Lazy<Type> = Lazy::new(|| Type::new(Token::boolean()).unwrap());
-    &*t
+    static TYP: Lazy<Type> = Lazy::new(|| Type::new(Token::boolean()).unwrap());
+    &*TYP
   }
 
   pub fn token(&self) -> Token {
@@ -100,21 +100,21 @@ impl Type {
 
   pub fn tag(&self) -> Tag {
     match &self {
-      Type::Simple{lexeme, width} => Tag::BASIC,
-      Type::Array { of, length } => Tag::INDEX
+      Type::Simple{lexeme: _, width: _} => Tag::BASIC,
+      Type::Array { of: _, length: _ } => Tag::INDEX
     }
   }
 
   pub fn width(&self) -> u32 {
     match &self {
-      Type::Simple{lexeme, width} => *width as u32,
+      Type::Simple{lexeme: _, width} => *width as u32,
       Type::Array { of, length } => of.width() * length
     }
   }
 
   fn is_numeric(&self) -> bool {
     match &self {
-      Type::Simple{lexeme, width} => match lexeme.as_str() {
+      Type::Simple{lexeme, width: _} => match lexeme.as_str() {
         "int" | "float" | "char" => true,
         _ => false
       },
@@ -129,7 +129,6 @@ impl Type {
     if left == Type::float() || right == Type::float() {
       return Some(Type::float().clone())
     }
-    let i = Type::integer();
     if left == Type::integer() || right == Type::integer() {
       return Some(Type::integer().clone())
     }
@@ -140,7 +139,7 @@ impl Type {
 impl fmt::Display for Type {
   fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
     match &self {
-      Type::Simple{lexeme, width} => write!(f, "{}", lexeme),
+      Type::Simple{lexeme, width: _} => write!(f, "{}", lexeme),
       Type::Array { of, length } => write!(f, "[{}]{}", length, *of)
     }
   }

--- a/rust/inter/inter.rs
+++ b/rust/inter/inter.rs
@@ -69,22 +69,22 @@ impl Type {
     Type::Array { of: Box::new(of), length: size }
   }
 
-  fn integer() -> &'static Type {
+  pub fn integer() -> &'static Type {
     static TYP: Lazy<Type> = Lazy::new(|| Type::new(Token::integer()).unwrap());
     &*TYP
   }
 
-  fn float() -> &'static Type {
+  pub fn float() -> &'static Type {
     static TYP: Lazy<Type> = Lazy::new(|| Type::new(Token::float()).unwrap());
     &*TYP
   }
 
-  fn ch() -> &'static Type {
+  pub fn ch() -> &'static Type {
     static TYP: Lazy<Type> = Lazy::new(|| Type::new(Token::ch()).unwrap());
     &*TYP
   }
 
-  fn boolean() -> &'static Type {
+  pub fn boolean() -> &'static Type {
     static TYP: Lazy<Type> = Lazy::new(|| Type::new(Token::boolean()).unwrap());
     &*TYP
   }

--- a/rust/inter/statement.rs
+++ b/rust/inter/statement.rs
@@ -299,18 +299,18 @@ impl Statement for DoStmt {
 }
 
 pub struct BreakStmt<'a> {
-  enclosing: &'a Box<dyn Statement>
+  enclosing: &'a dyn Statement
 }
 
 impl BreakStmt<'_> {
-  pub fn new<'a>(enclosing: &'a Box<dyn Statement>) -> Result<BreakStmt<'a>, String> {
+  pub fn new<'a>(enclosing: &'a dyn Statement) -> Result<BreakStmt<'a>, String> {
     if enclosing.is_null() {
       return Err(String::from("Unenclosed break"))
     }
     Ok(BreakStmt { enclosing: enclosing })
   }
 
-  pub fn new_box<'a>(enclosing: &'a Box<dyn Statement>) -> Result<Box<BreakStmt<'a>>, String> {
+  pub fn new_box<'a>(enclosing: &'a dyn Statement) -> Result<Box<BreakStmt<'a>>, String> {
     let bs = BreakStmt::new(enclosing)?;
     Ok(Box::new(bs))
   }

--- a/rust/inter/statement.rs
+++ b/rust/inter/statement.rs
@@ -150,14 +150,14 @@ pub struct IfStmt {
 }
 
 impl IfStmt {
-  fn new(cond: Box<dyn Expression>, body: Box<dyn Statement>) -> Result<IfStmt, String> {
+  pub fn new(cond: Box<dyn Expression>, body: Box<dyn Statement>) -> Result<IfStmt, String> {
     if cond.typ() != Type::boolean() {
       return Err(String::from("If condition should be of bool type"))
     }
     Ok(IfStmt {cond: cond, body: body})
   }
 
-  fn new_box(cond: Box<dyn Expression>, body: Box<dyn Statement>) -> Result<Box<IfStmt>, String> {
+  pub fn new_box(cond: Box<dyn Expression>, body: Box<dyn Statement>) -> Result<Box<IfStmt>, String> {
     let is = IfStmt::new(cond, body)?;
     Ok(Box::new(is))
   }
@@ -310,7 +310,7 @@ use super::*;
 
 #[test]
 fn statement_tests() {
-  let mut tests: Vec<(Box<dyn Statement>, &str)> = vec![
+  let tests: Vec<(Box<dyn Statement>, &str)> = vec![
     (
       AssignStmt::new_box(
         Identifier::new_box(Token::from_str("x"), Type::integer(), 4),

--- a/rust/lexer/tokens.rs
+++ b/rust/lexer/tokens.rs
@@ -153,6 +153,13 @@ impl Token {
     &*a
   }
 
+  pub fn minus_word() -> &'static Token {
+    static m: Lazy<Token> = Lazy::new(|| {
+      Token::Word(String::from("minus"), Tag::MINUS)
+    });
+    &*m
+  }
+
   pub fn tag(&self) -> u32 {
     match self {
       Token::Tok(tg) => *tg as u32,

--- a/rust/parser/BUILD
+++ b/rust/parser/BUILD
@@ -15,6 +15,7 @@ rust_test(
   name = "parser_test",
   crate = ":parser",
   deps = [
-     "@crate_index//:stringreader",
+    "@crate_index//:once_cell",
+    "@crate_index//:stringreader",
   ],
 )


### PR DESCRIPTION
This is the part that departures the most from the reference implementation. The reason is the reference that the
break statement holds to the enclosing statement. While probably not impossible, it is hard to argue that the 
ancestor will outlive the break node.

In order to overcome the issue, the opposite approach from the reference is then implemented, instead of requesting
the label of the enclosing statement, the enclosing statement pushes it down.